### PR TITLE
MC-31906: [BUG] Critical error while saving category

### DIFF
--- a/app/code/Magento/CatalogStorefront/Model/MessageBus/Consumer.php
+++ b/app/code/Magento/CatalogStorefront/Model/MessageBus/Consumer.php
@@ -91,7 +91,6 @@ class Consumer
     private function collectDataByEntityTypeAnsScope(array $messages): array
     {
         $dataPerType = [];
-        $messages = array_merge(...$messages);
         foreach ($messages as $message) {
             $entity = $this->catalogItemMessageBuilder->build($message);
             $entityData = $entity->getEntityData();

--- a/app/code/Magento/CatalogStorefront/etc/queue_consumer.xml
+++ b/app/code/Magento/CatalogStorefront/etc/queue_consumer.xml
@@ -6,5 +6,5 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/consumer.xsd">
-    <consumer name="storefront.catalog.data.consume" queue="storefront.catalog.data.consume" connection="amqp" consumerInstance="Magento\Framework\MessageQueue\BatchConsumer" handler="Magento\CatalogStorefront\Model\MessageBus\Consumer::process" maxMessages="5000" />
+    <consumer name="storefront.catalog.data.consume" queue="storefront.catalog.data.consume" connection="amqp" consumerInstance="Magento\Framework\MessageQueue\Consumer" handler="Magento\CatalogStorefront\Model\MessageBus\Consumer::process" maxMessages="5000" />
 </config>

--- a/app/code/Magento/CatalogStorefrontConnector/Model/CategoriesQueueConsumer.php
+++ b/app/code/Magento/CatalogStorefrontConnector/Model/CategoriesQueueConsumer.php
@@ -34,13 +34,13 @@ class CategoriesQueueConsumer
      * Process messages from storefront.collect.updated.categories.data topic
      * and publish new messages to storefront.catalog.data.consume topic
      *
-     * @param UpdatedEntitiesDataInterface[] $messages
+     * @param UpdatedEntitiesDataInterface $message
      * @return void
      * @throws \Exception
      */
-    public function processMessages(array $messages): void
+    public function processMessages(UpdatedEntitiesDataInterface $message): void
     {
-        $storeCategories = $this->getUniqueIdsForStores($messages);
+        $storeCategories = $this->getUniqueIdsForStores([$message]);
         foreach ($storeCategories as $storeId => $categoryIds) {
             $this->categoryPublisher->publish($categoryIds, $storeId);
         }

--- a/app/code/Magento/CatalogStorefrontConnector/Model/ProductsQueueConsumer.php
+++ b/app/code/Magento/CatalogStorefrontConnector/Model/ProductsQueueConsumer.php
@@ -6,6 +6,7 @@
 
 namespace Magento\CatalogStorefrontConnector\Model;
 
+use Magento\CatalogStorefrontConnector\Model\Data\UpdatedEntitiesData;
 use Magento\CatalogStorefrontConnector\Model\Publisher\CatalogEntityIdsProvider;
 use Magento\CatalogStorefrontConnector\Model\Publisher\ProductPublisher;
 use Magento\CatalogStorefrontConnector\Model\Data\UpdatedEntitiesDataInterface;
@@ -43,13 +44,13 @@ class ProductsQueueConsumer
      * Process messages from storefront.catalog.product.update topic
      * and publish new messages to storefront.catalog.data.consume
      *
-     * @param UpdatedEntitiesDataInterface[] $messages
+     * @param UpdatedEntitiesDataInterface $message
      * @return void
-     * @throws \Exception
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function processMessages(array $messages): void
+    public function processMessages(UpdatedEntitiesDataInterface $message): void
     {
-        $storeProducts = $this->getUniqueIdsForStores($messages);
+        $storeProducts = $this->getUniqueIdsForStores([$message]);
         foreach ($storeProducts as $storeId => $productIds) {
             if (empty($productIds)) {
                 foreach ($this->catalogEntityIdsProvider->getProductIds($storeId) as $ids) {
@@ -70,7 +71,7 @@ class ProductsQueueConsumer
     private function getUniqueIdsForStores(array $messages): array
     {
         $storesProductIds = [];
-        /** @var \Magento\CatalogStorefrontConnector\Model\Data\UpdatedEntitiesData $updatedProductsData */
+        /** @var UpdatedEntitiesData $updatedProductsData */
         foreach ($messages as $updatedProductsData) {
             $storeId = $updatedProductsData->getStoreId();
             if (empty($updatedProductsData->getEntityIds())) {

--- a/app/code/Magento/CatalogStorefrontConnector/etc/queue_consumer.xml
+++ b/app/code/Magento/CatalogStorefrontConnector/etc/queue_consumer.xml
@@ -6,6 +6,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/consumer.xsd">
-    <consumer name="storefront.catalog.product.update" queue="storefront.catalog.product.connector" connection="amqp" consumerInstance="Magento\Framework\MessageQueue\BatchConsumer" handler="Magento\CatalogStorefrontConnector\Model\ProductsQueueConsumer::processMessages"/>
-    <consumer name="storefront.catalog.category.update" queue="storefront.catalog.category.connector" connection="amqp" consumerInstance="Magento\Framework\MessageQueue\BatchConsumer" handler="Magento\CatalogStorefrontConnector\Model\CategoriesQueueConsumer::processMessages"/>
+    <consumer name="storefront.catalog.product.update" queue="storefront.catalog.product.connector" connection="amqp" consumerInstance="Magento\Framework\MessageQueue\Consumer" handler="Magento\CatalogStorefrontConnector\Model\ProductsQueueConsumer::processMessages"/>
+    <consumer name="storefront.catalog.category.update" queue="storefront.catalog.category.connector" connection="amqp" consumerInstance="Magento\Framework\MessageQueue\Consumer" handler="Magento\CatalogStorefrontConnector\Model\CategoriesQueueConsumer::processMessages"/>
 </config>

--- a/dev/tests/api-functional/framework/Magento/TestFramework/Annotation/QueueTrigger.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/Annotation/QueueTrigger.php
@@ -39,8 +39,8 @@ class QueueTrigger
     private function waitForAsynchronousResult(): void
     {
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        /** @var \Magento\StorefrontTestFixer\ConsumerInvoker $consumerInvoker */
-        $consumerInvoker = $objectManager->get(\Magento\StorefrontTestFixer\ConsumerInvoker::class);
+        /** @var \Magento\TestFramework\Workaround\ConsumerInvoker $consumerInvoker */
+        $consumerInvoker = $objectManager->get(\Magento\TestFramework\Workaround\ConsumerInvoker::class);
         $consumerInvoker->invoke();
     }
 }

--- a/dev/tests/api-functional/framework/Magento/TestFramework/WebApiApplication.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/WebApiApplication.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\TestFramework;
+
+/**
+ * Override \Magento\TestFramework\WebApiApplication to be able provide install configuration with empty values
+ *
+ * Should be eliminated after resolving MC-32269 for 2.4
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ */
+class WebApiApplication extends Application
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function run()
+    {
+        throw new \Exception(
+            "Can't start application: purpose of Web API Application is to use classes and models from the application"
+            . " and don't run it"
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function install($cleanup)
+    {
+        if ($cleanup) {
+            $this->cleanup();
+        }
+
+        $installOptions = $this->getInstallConfig();
+
+        /* Install application */
+        if ($installOptions) {
+            $installCmd = 'php -f ' . BP . '/bin/magento setup:install -vvv';
+            $installArgs = [];
+            foreach ($installOptions as $optionName => $optionValue) {
+                if (is_bool($optionValue)) {
+                    if (true === $optionValue) {
+                        $installCmd .= " --$optionName";
+                    }
+                    continue;
+                }
+                $installCmd .= " --$optionName=%s";
+                $installArgs[] = $optionValue;
+            }
+            $this->_shell->execute($installCmd, $installArgs);
+        }
+    }
+
+    /**
+     * Use the application as is
+     *
+     * {@inheritdoc}
+     */
+    protected function getCustomDirs()
+    {
+        return [];
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/CategoriesOnConfigurationChange.php
+++ b/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/CategoriesOnConfigurationChange.php
@@ -41,8 +41,8 @@ class CategoriesOnConfigurationChange extends UpdateCategoriesOnConfigurationCha
             $scopeId
         );
         $objectManager = Bootstrap::getObjectManager();
-        /** @var ConsumerInvoker $consumerInvoker */
-        $consumerInvoker = $objectManager->get(ConsumerInvoker::class);
+        /** @var \Magento\TestFramework\Workaround\ConsumerInvoker $consumerInvoker */
+        $consumerInvoker = $objectManager->get(\Magento\TestFramework\Workaround\ConsumerInvoker::class);
         $consumerInvoker->invoke(true);
 
         return $result;

--- a/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/CategoryAfterSave.php
+++ b/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/CategoryAfterSave.php
@@ -32,8 +32,8 @@ class CategoryAfterSave extends CollectCategoriesDataOnSave
         $result = parent::afterSave($subject, $result, $category);
 
         $objectManager = Bootstrap::getObjectManager();
-        /** @var ConsumerInvoker $consumerInvoker */
-        $consumerInvoker = $objectManager->get(ConsumerInvoker::class);
+        /** @var \Magento\TestFramework\Workaround\ConsumerInvoker $consumerInvoker */
+        $consumerInvoker = $objectManager->get(\Magento\TestFramework\Workaround\ConsumerInvoker::class);
         $consumerInvoker->invoke(true);
 
         return $result;

--- a/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/CategoryOnDelete.php
+++ b/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/CategoryOnDelete.php
@@ -31,8 +31,8 @@ class CategoryOnDelete extends \Magento\CatalogStorefrontConnector\Plugin\Catego
         $result = parent::afterDelete($subject, $result, $category);
 
         $objectManager = Bootstrap::getObjectManager();
-        /** @var ConsumerInvoker $consumerInvoker */
-        $consumerInvoker = $objectManager->get(ConsumerInvoker::class);
+        /** @var \Magento\TestFramework\Workaround\ConsumerInvoker $consumerInvoker */
+        $consumerInvoker = $objectManager->get(\Magento\TestFramework\Workaround\ConsumerInvoker::class);
         $consumerInvoker->invoke(true);
 
         return $result;

--- a/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/CategoryOnUpdate.php
+++ b/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/CategoryOnUpdate.php
@@ -32,8 +32,8 @@ class CategoryOnUpdate extends CollectCategoriesDataForUpdate
         $result = parent::afterExecute($subject, $result, $entityIds, $useTempTable);
 
         $objectManager = Bootstrap::getObjectManager();
-        /** @var ConsumerInvoker $consumerInvoker */
-        $consumerInvoker = $objectManager->get(ConsumerInvoker::class);
+        /** @var \Magento\TestFramework\Workaround\ConsumerInvoker $consumerInvoker */
+        $consumerInvoker = $objectManager->get(\Magento\TestFramework\Workaround\ConsumerInvoker::class);
         $consumerInvoker->invoke(true);
 
         return $result;

--- a/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/ProductAfterSave.php
+++ b/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/ProductAfterSave.php
@@ -32,8 +32,8 @@ class ProductAfterSave extends CollectProductsDataOnSave
         $result = parent::afterSave($subject, $result, $product);
 
         $objectManager = Bootstrap::getObjectManager();
-        /** @var ConsumerInvoker $consumerInvoker */
-        $consumerInvoker = $objectManager->get(ConsumerInvoker::class);
+        /** @var \Magento\TestFramework\Workaround\ConsumerInvoker $consumerInvoker */
+        $consumerInvoker = $objectManager->get(\Magento\TestFramework\Workaround\ConsumerInvoker::class);
         $consumerInvoker->invoke(true);
 
         return $result;
@@ -54,8 +54,8 @@ class ProductAfterSave extends CollectProductsDataOnSave
         $result = parent::afterDelete($subject, $result, $product);
 
         $objectManager = Bootstrap::getObjectManager();
-        /** @var ConsumerInvoker $consumerInvoker */
-        $consumerInvoker = $objectManager->get(ConsumerInvoker::class);
+        /** @var \Magento\TestFramework\Workaround\ConsumerInvoker $consumerInvoker */
+        $consumerInvoker = $objectManager->get(\Magento\TestFramework\Workaround\ConsumerInvoker::class);
         $consumerInvoker->invoke(true);
 
         return $result;

--- a/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/StockStatusUpdate.php
+++ b/dev/tests/api-functional/testsuite/Magento/StorefrontTestFixer/StockStatusUpdate.php
@@ -33,8 +33,8 @@ class StockStatusUpdate extends CollectProductsDataForUpdateAfterStockUpdate
         $result = parent::afterUpdateStockItemBySku($subject, $result, $productSku, $stockItem);
 
         $objectManager = Bootstrap::getObjectManager();
-        /** @var ConsumerInvoker $consumerInvoker */
-        $consumerInvoker = $objectManager->get(ConsumerInvoker::class);
+        /** @var \Magento\TestFramework\Workaround\ConsumerInvoker $consumerInvoker */
+        $consumerInvoker = $objectManager->get(\Magento\TestFramework\Workaround\ConsumerInvoker::class);
         $consumerInvoker->invoke(true);
 
         return $result;

--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -1,0 +1,719 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\TestFramework;
+
+use Magento\Framework\Autoload\AutoloaderInterface;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Config\ConfigOptionsListConstants;
+use Magento\Framework\App\DeploymentConfig\Reader;
+use Magento\Framework\Filesystem\Glob;
+
+/**
+ * Override \Magento\TestFramework\Application to be able provide install configuration with empty values
+ *
+ * Should be eliminated after resolving MC-32269 for 2.4
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ */
+class Application
+{
+    /**
+     * Default application area.
+     */
+    const DEFAULT_APP_AREA = 'global';
+
+    /**
+     * DB vendor adapter instance.
+     *
+     * @var \Magento\TestFramework\Db\AbstractDb
+     */
+    protected $_db;
+
+    /**
+     * Shell command executor.
+     *
+     * @var \Magento\Framework\Shell
+     */
+    protected $_shell;
+
+    /**
+     * Configuration file that contains installation parameters.
+     *
+     * @var string
+     */
+    private $installConfigFile;
+
+    /**
+     * The loaded installation parameters.
+     *
+     * @var array
+     */
+    protected $installConfig;
+
+    /**
+     * Application *.xml configuration files.
+     *
+     * @var array
+     */
+    protected $_globalConfigDir;
+
+    /**
+     * Installation destination directory.
+     *
+     * @var string
+     */
+    protected $installDir;
+
+    /**
+     * Installation destination directory with configuration files.
+     *
+     * @var string
+     */
+    protected $_configDir;
+
+    /**
+     * Application initialization parameters.
+     *
+     * @var array
+     */
+    protected $_initParams = [];
+
+    /**
+     * Mode to run application.
+     *
+     * @var string
+     */
+    protected $_appMode;
+
+    /**
+     * Application area.
+     *
+     * @var null
+     */
+    protected $_appArea = null;
+
+    /**
+     * Primary DI Config.
+     *
+     * @var array
+     */
+    protected $_primaryConfigData = [];
+
+    /**
+     * Object manager factory.
+     *
+     * @var \Magento\TestFramework\ObjectManagerFactory
+     */
+    protected $_factory;
+
+    /**
+     * Directory list.
+     *
+     * @var \Magento\Framework\App\Filesystem\DirectoryList
+     */
+    protected $dirList;
+
+    /**
+     * Config file for integration tests.
+     *
+     * @var string
+     */
+    private $globalConfigFile;
+
+    /**
+     * Defines whether load test extension attributes or not.
+     *
+     * @var bool
+     */
+    private $loadTestExtensionAttributes;
+
+    /**
+     * @var bool
+     */
+    protected $dumpDb = true;
+
+    /**
+     * @var bool
+     */
+    protected $canLoadArea = true;
+
+    /**
+     * @var bool
+     */
+    protected $canInstallSequence = true;
+
+    /**
+     * Constructor.
+     *
+     * @param \Magento\Framework\Shell $shell
+     * @param string $installDir
+     * @param array $installConfigFile
+     * @param string $globalConfigFile
+     * @param string $globalConfigDir
+     * @param string $appMode
+     * @param AutoloaderInterface $autoloadWrapper
+     * @param bool|null $loadTestExtensionAttributes
+     */
+    public function __construct(
+        \Magento\Framework\Shell $shell,
+        $installDir,
+        $installConfigFile,
+        $globalConfigFile,
+        $globalConfigDir,
+        $appMode,
+        AutoloaderInterface $autoloadWrapper,
+        $loadTestExtensionAttributes = false
+    ) {
+        if (getcwd() != BP . '/dev/tests/integration') {
+            chdir(BP . '/dev/tests/integration');
+        }
+        $this->_shell = $shell;
+        $this->installConfigFile = $installConfigFile;
+        $this->_globalConfigDir = realpath($globalConfigDir);
+        $this->_appMode = $appMode;
+        $this->installDir = $installDir;
+        $this->loadTestExtensionAttributes = $loadTestExtensionAttributes;
+
+        $customDirs = $this->getCustomDirs();
+        $this->dirList = new \Magento\Framework\App\Filesystem\DirectoryList(BP, $customDirs);
+        \Magento\Framework\Autoload\Populator::populateMappings(
+            $autoloadWrapper,
+            $this->dirList
+        );
+        $this->_initParams = [
+            \Magento\Framework\App\Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS => $customDirs,
+            \Magento\Framework\App\State::PARAM_MODE => $appMode
+        ];
+        $driverPool = new \Magento\Framework\Filesystem\DriverPool;
+        $configFilePool = new \Magento\Framework\Config\File\ConfigFilePool;
+        $this->_factory = new \Magento\TestFramework\ObjectManagerFactory($this->dirList, $driverPool, $configFilePool);
+
+        $this->_configDir = $this->dirList->getPath(DirectoryList::CONFIG);
+        $this->globalConfigFile = $globalConfigFile;
+    }
+
+    /**
+     * Retrieve the database adapter instance.
+     *
+     * @return \Magento\TestFramework\Db\AbstractDb
+     */
+    public function getDbInstance()
+    {
+        if (null === $this->_db) {
+            if ($this->isInstalled()) {
+                $configPool = new \Magento\Framework\Config\File\ConfigFilePool();
+                $driverPool = new \Magento\Framework\Filesystem\DriverPool();
+                $reader = new Reader($this->dirList, $driverPool, $configPool);
+                $deploymentConfig = new DeploymentConfig($reader, []);
+                $host = $deploymentConfig->get(
+                    ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT .
+                    '/' . ConfigOptionsListConstants::KEY_HOST
+                );
+                $user = $deploymentConfig->get(
+                    ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT .
+                    '/' . ConfigOptionsListConstants::KEY_USER
+                );
+                $password = $deploymentConfig->get(
+                    ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT .
+                    '/' . ConfigOptionsListConstants::KEY_PASSWORD
+                );
+                $dbName = $deploymentConfig->get(
+                    ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT .
+                    '/' . ConfigOptionsListConstants::KEY_NAME
+                );
+            } else {
+                $installConfig = $this->getInstallConfig();
+                $host = $installConfig['db-host'];
+                $user = $installConfig['db-user'];
+                $password = $installConfig['db-password'];
+                $dbName = $installConfig['db-name'];
+            }
+            $this->_db = new Db\Mysql(
+                $host,
+                $user,
+                $password,
+                $dbName,
+                $this->getTempDir(),
+                $this->_shell
+            );
+        }
+        return $this->_db;
+    }
+
+    /**
+     * Gets installation parameters.
+     *
+     * @return array
+     */
+    protected function getInstallConfig()
+    {
+        if (null === $this->installConfig) {
+            $this->installConfig = include $this->installConfigFile;
+        }
+        return $this->installConfig;
+    }
+
+    /**
+     * Gets deployment configuration path.
+     *
+     * @return string
+     */
+    private function getLocalConfig()
+    {
+        return $this->_configDir . '/config.php';
+    }
+
+    /**
+     * Get path to temporary directory.
+     *
+     * @return string
+     */
+    public function getTempDir()
+    {
+        return $this->installDir;
+    }
+
+    /**
+     * Retrieve application initialization parameters.
+     *
+     * @return array
+     */
+    public function getInitParams()
+    {
+        return $this->_initParams;
+    }
+
+    /**
+     * Weather the application is installed or not.
+     *
+     * @return bool
+     */
+    public function isInstalled()
+    {
+        return is_file($this->getLocalConfig());
+    }
+
+    /**
+     * Create logger instance and rewrite already exist one in ObjectManager.
+     *
+     * @return \Psr\Log\LoggerInterface
+     */
+    private function initLogger()
+    {
+        $objectManager = Helper\Bootstrap::getObjectManager();
+        /** @var \Psr\Log\LoggerInterface $logger */
+        $logger = $objectManager->create(
+            \Magento\TestFramework\ErrorLog\Logger::class,
+            [
+                'name' => 'integration-tests',
+                'handlers' => [
+                    'system' => $objectManager->create(
+                        \Magento\Framework\Logger\Handler\System::class,
+                        [
+                            'exceptionHandler' => $objectManager->create(
+                                \Magento\Framework\Logger\Handler\Exception::class,
+                                ['filePath' => $this->installDir]
+                            ),
+                            'filePath' => $this->installDir
+                        ]
+                    ),
+                    'debug'  => $objectManager->create(
+                        \Magento\Framework\Logger\Handler\Debug::class,
+                        ['filePath' => $this->installDir]
+                    ),
+                ]
+            ]
+        );
+
+        $objectManager->removeSharedInstance(\Magento\Framework\Logger\Monolog::class);
+        $objectManager->addSharedInstance($logger, \Magento\Framework\Logger\Monolog::class);
+        return $logger;
+    }
+
+    /**
+     * Initialize application
+     *
+     * @param array $overriddenParams
+     * @return void
+     */
+    public function initialize($overriddenParams = [])
+    {
+        $overriddenParams[\Magento\Framework\App\State::PARAM_MODE] = $this->_appMode;
+        $overriddenParams = $this->_customizeParams($overriddenParams);
+        $directories = isset($overriddenParams[\Magento\Framework\App\Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS])
+            ? $overriddenParams[\Magento\Framework\App\Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS]
+            : [];
+        $directoryList = new DirectoryList(BP, $directories);
+        /** @var \Magento\TestFramework\ObjectManager $objectManager */
+        $objectManager = Helper\Bootstrap::getObjectManager();
+        if (!$objectManager) {
+            $objectManager = $this->_factory->create($overriddenParams);
+            $objectManager->addSharedInstance($directoryList, \Magento\Framework\App\Filesystem\DirectoryList::class);
+            $objectManager->addSharedInstance($directoryList, \Magento\Framework\Filesystem\DirectoryList::class);
+        } else {
+            $objectManager = $this->_factory->restore($objectManager, $directoryList, $overriddenParams);
+        }
+        /** @var \Magento\TestFramework\App\Filesystem $filesystem */
+        $filesystem = $objectManager->get(\Magento\TestFramework\App\Filesystem::class);
+        $objectManager->removeSharedInstance(\Magento\Framework\Filesystem::class);
+        $objectManager->addSharedInstance($filesystem, \Magento\Framework\Filesystem::class);
+        Helper\Bootstrap::setObjectManager($objectManager);
+        $this->initLogger();
+        $sequenceBuilder = $objectManager->get(\Magento\TestFramework\Db\Sequence\Builder::class);
+        $objectManager->addSharedInstance($sequenceBuilder, \Magento\SalesSequence\Model\Builder::class);
+
+        $objectManagerConfiguration = [
+            'preferences' => [
+                \Magento\Framework\App\State::class => \Magento\TestFramework\App\State::class,
+                \Magento\Framework\Mail\TransportInterface::class =>
+                    \Magento\TestFramework\Mail\TransportInterfaceMock::class,
+                \Magento\Framework\Mail\Template\TransportBuilder::class
+                => \Magento\TestFramework\Mail\Template\TransportBuilderMock::class,
+            ]
+        ];
+        if ($this->loadTestExtensionAttributes) {
+            $objectManagerConfiguration = array_merge(
+                $objectManagerConfiguration,
+                [
+                    \Magento\Framework\Api\ExtensionAttribute\Config\Reader::class => [
+                        'arguments' => [
+                            'fileResolver' => [
+                                'instance' => \Magento\TestFramework\Api\Config\Reader\FileResolver::class
+                            ],
+                        ],
+                    ],
+                ]
+            );
+        }
+        $objectManager->configure($objectManagerConfiguration);
+        /** Register event observer of Integration Framework */
+        /** @var \Magento\Framework\Event\Config\Data $eventConfigData */
+        $eventConfigData = $objectManager->get(\Magento\Framework\Event\Config\Data::class);
+        $eventConfigData->merge(
+            [
+                'core_app_init_current_store_after' => [
+                    'integration_tests' => [
+                        'instance' => \Magento\TestFramework\Event\Magento::class,
+                        'name' => 'integration_tests'
+                    ]
+                ]
+            ]
+        );
+
+        if ($this->canLoadArea) {
+            $this->loadArea(\Magento\TestFramework\Application::DEFAULT_APP_AREA);
+        }
+
+        \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->configure(
+            $objectManager->get(\Magento\Framework\ObjectManager\DynamicConfigInterface::class)->getConfiguration()
+        );
+        \Magento\Framework\Phrase::setRenderer(
+            $objectManager->get(\Magento\Framework\Phrase\Renderer\Placeholder::class)
+        );
+
+        if ($this->canInstallSequence) {
+            /** @var \Magento\TestFramework\Db\Sequence $sequence */
+            $sequence = $objectManager->get(\Magento\TestFramework\Db\Sequence::class);
+            $sequence->generateSequences();
+        }
+
+        $objectManager->create(\Magento\TestFramework\Config::class, ['configPath' => $this->globalConfigFile])
+            ->rewriteAdditionalConfig();
+    }
+
+    /**
+     * Reset and initialize again an already installed application
+     *
+     * @param array $overriddenParams
+     * @return void
+     */
+    public function reinitialize(array $overriddenParams = [])
+    {
+        $this->_resetApp();
+        $this->initialize($overriddenParams);
+    }
+
+    /**
+     * Run application normally, but with encapsulated initialization options
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        /** @var \Magento\Framework\App\Http $app */
+        $app = $objectManager->get(\Magento\Framework\App\Http::class);
+        $response = $app->launch();
+        $response->sendResponse();
+    }
+
+    /**
+     * Create install dir for integration framework
+     *
+     * @return void
+     */
+    public function createInstallDir()
+    {
+        $this->_ensureDirExists($this->installDir);
+        $this->_ensureDirExists($this->_configDir);
+
+        $this->copyAppConfigFiles();
+    }
+
+    /**
+     * Cleanup both the database and the file system
+     *
+     * @return void
+     */
+    public function cleanup()
+    {
+        $this->createInstallDir();
+        /**
+         * @see \Magento\Setup\Mvc\Bootstrap\InitParamListener::BOOTSTRAP_PARAM
+         */
+        $this->_shell->execute(
+            PHP_BINARY . ' -f %s setup:uninstall -vvv -n --magento-init-params=%s',
+            [BP . '/bin/magento', $this->getInitParamsQuery()]
+        );
+    }
+
+    /**
+     * Install an application
+     *
+     * @param bool $cleanup
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function install($cleanup)
+    {
+        $dirs = \Magento\Framework\App\Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS;
+        $this->_ensureDirExists($this->installDir);
+        $this->_ensureDirExists($this->_configDir);
+        $this->_ensureDirExists($this->_initParams[$dirs][DirectoryList::PUB][DirectoryList::PATH]);
+        $this->_ensureDirExists($this->_initParams[$dirs][DirectoryList::MEDIA][DirectoryList::PATH]);
+        $this->_ensureDirExists($this->_initParams[$dirs][DirectoryList::STATIC_VIEW][DirectoryList::PATH]);
+        $this->_ensureDirExists($this->_initParams[$dirs][DirectoryList::VAR_DIR][DirectoryList::PATH]);
+
+        $this->copyAppConfigFiles();
+        $this->copyGlobalConfigFile();
+
+        $installParams = $this->getInstallCliParams();
+
+        // performance optimization: restore DB from last good dump to make installation on top of it (much faster)
+        // do not restore from the database if the cleanup option is set to ensure we have a clean DB to test on
+        $db = $this->getDbInstance();
+        if ($db->isDbDumpExists() && !$cleanup) {
+            $db->restoreFromDbDump();
+        }
+
+        // run install script
+        $this->_shell->execute(
+            PHP_BINARY . ' -f %s setup:install -vvv ' . implode(' ', array_keys($installParams)),
+            array_merge([BP . '/bin/magento'], array_values($installParams))
+        );
+
+        // enable only specified list of caches
+        $initParamsQuery = $this->getInitParamsQuery();
+        $this->_shell->execute(
+            PHP_BINARY . ' -f %s cache:disable -vvv --bootstrap=%s',
+            [BP . '/bin/magento', $initParamsQuery]
+        );
+        $this->_shell->execute(
+            PHP_BINARY . ' -f %s cache:enable -vvv %s %s %s %s --bootstrap=%s',
+            [
+                BP . '/bin/magento',
+                \Magento\Framework\App\Cache\Type\Config::TYPE_IDENTIFIER,
+                \Magento\Framework\App\Cache\Type\Layout::TYPE_IDENTIFIER,
+                \Magento\Framework\App\Cache\Type\Translate::TYPE_IDENTIFIER,
+                \Magento\Eav\Model\Cache\Type::TYPE_IDENTIFIER,
+                $initParamsQuery,
+            ]
+        );
+
+        // right after a clean installation, store DB dump for future reuse in tests or running the test suite again
+        if (!$db->isDbDumpExists() && $this->dumpDb) {
+            $this->getDbInstance()->storeDbDump();
+        }
+    }
+
+    /**
+     * Copies configuration files from the main code base, so the installation could proceed in the tests directory
+     *
+     * @return void
+     */
+    private function copyAppConfigFiles()
+    {
+        $globalConfigFiles = Glob::glob(
+            $this->_globalConfigDir . '/{di.xml,*/di.xml,db_schema.xml,vendor_path.php}',
+            Glob::GLOB_BRACE
+        );
+        foreach ($globalConfigFiles as $file) {
+            $targetFile = $this->_configDir . str_replace($this->_globalConfigDir, '', $file);
+            $this->_ensureDirExists(dirname($targetFile));
+            if ($file !== $targetFile) {
+                copy($file, $targetFile);
+            }
+        }
+    }
+
+    /**
+     * Copies global configuration file from the tests folder (see TESTS_GLOBAL_CONFIG_FILE)
+     *
+     * @return void
+     */
+    private function copyGlobalConfigFile()
+    {
+        $targetFile = $this->_configDir . '/config.local.php';
+        copy($this->globalConfigFile, $targetFile);
+    }
+
+    /**
+     * Gets a list of CLI params for installation
+     *
+     * @return array
+     */
+    private function getInstallCliParams()
+    {
+        $params = $this->getInstallConfig();
+        /**
+         * Literal value is used instead of constant, because autoloader is not integrated with Magento Setup app
+         * @see \Magento\Setup\Mvc\Bootstrap\InitParamListener::BOOTSTRAP_PARAM
+         */
+        $params['magento-init-params'] = $this->getInitParamsQuery();
+        $result = [];
+        foreach ($params as $key => $value) {
+            $result["--{$key}=%s"] = $value;
+        }
+        return $result;
+    }
+
+    /**
+     * Encodes init params into a query string
+     *
+     * @return string
+     */
+    private function getInitParamsQuery()
+    {
+        return urldecode(http_build_query($this->_initParams));
+    }
+
+    /**
+     * Sub-routine for merging custom parameters with the ones defined in object state
+     *
+     * @param array $params
+     * @return array
+     */
+    public function _customizeParams($params)
+    {
+        return array_replace_recursive($this->_initParams, $params);
+    }
+
+    /**
+     * Reset application global state
+     */
+    protected function _resetApp()
+    {
+        /** @var $objectManager \Magento\TestFramework\ObjectManager */
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager->clearCache();
+        \Magento\Framework\Data\Form::setElementRenderer(null);
+        \Magento\Framework\Data\Form::setFieldsetRenderer(null);
+        \Magento\Framework\Data\Form::setFieldsetElementRenderer(null);
+        $this->_appArea = null;
+    }
+
+    /**
+     * Create a directory with write permissions or don't touch existing one
+     *
+     * @param string $dir
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    protected function _ensureDirExists($dir)
+    {
+        if (!file_exists($dir)) {
+            $old = umask(0);
+            mkdir($dir, 0777, true);
+            umask($old);
+        } elseif (!is_dir($dir)) {
+            throw new \Magento\Framework\Exception\LocalizedException(__("'%1' is not a directory.", $dir));
+        }
+    }
+
+    /**
+     * Ge current application area
+     *
+     * @return string
+     */
+    public function getArea()
+    {
+        return $this->_appArea;
+    }
+
+    /**
+     * Load application area
+     *
+     * @param string $areaCode
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function loadArea($areaCode)
+    {
+        $this->_appArea = $areaCode;
+        $scope = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+            \Magento\Framework\Config\Scope::class
+        );
+        $scope->setCurrentScope($areaCode);
+        \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->configure(
+            \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+                \Magento\Framework\App\ObjectManager\ConfigLoader::class
+            )->load(
+                $areaCode
+            )
+        );
+        $app = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\App\AreaList::class);
+        $areasForPartialLoading = [
+            \Magento\Framework\App\Area::AREA_GLOBAL,
+            \Magento\Framework\App\Area::AREA_WEBAPI_REST,
+            \Magento\Framework\App\Area::AREA_WEBAPI_SOAP,
+            \Magento\Framework\App\Area::AREA_CRONTAB,
+            \Magento\Framework\App\Area::AREA_GRAPHQL
+        ];
+        if (in_array($areaCode, $areasForPartialLoading, true)) {
+            $app->getArea($areaCode)->load(\Magento\Framework\App\Area::PART_CONFIG);
+        } else {
+            \Magento\TestFramework\Helper\Bootstrap::getInstance()->loadArea($areaCode);
+        }
+    }
+
+    /**
+     * Gets customized directory paths
+     *
+     * @return array
+     */
+    protected function getCustomDirs()
+    {
+        $path = DirectoryList::PATH;
+        $var = "{$this->installDir}/var";
+        $generated = "{$this->installDir}/generated";
+        $customDirs = [
+            DirectoryList::CONFIG => [$path => "{$this->installDir}/etc"],
+            DirectoryList::VAR_DIR => [$path => $var],
+            DirectoryList::MEDIA => [$path => "{$this->installDir}/pub/media"],
+            DirectoryList::STATIC_VIEW => [$path => "{$this->installDir}/pub/static"],
+            DirectoryList::TMP_MATERIALIZATION_DIR => [$path => "{$var}/view_preprocessed/pub/static"],
+            DirectoryList::GENERATED_CODE => [$path => "{$generated}/code"],
+            DirectoryList::CACHE => [$path => "{$var}/cache"],
+            DirectoryList::LOG => [$path => "{$var}/log"],
+            DirectoryList::SESSION => [$path => "{$var}/session"],
+            DirectoryList::TMP => [$path => "{$var}/tmp"],
+            DirectoryList::UPLOAD => [$path => "{$var}/upload"],
+            DirectoryList::PUB => [$path => "{$this->installDir}/pub"],
+        ];
+        return $customDirs;
+    }
+}

--- a/dev/tests/integration/framework/Magento/TestFramework/Workaround/ConsumerInvoker.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Workaround/ConsumerInvoker.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\StorefrontTestFixer;
+namespace Magento\TestFramework\Workaround;
 
 use Magento\TestFramework\Helper\Bootstrap;
 
@@ -32,14 +32,17 @@ class ConsumerInvoker
      * Invoke consumers
      *
      * @param bool $invokeInTestsOnly
+     * @param array $consumersToProcess
      * @return void
      * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \ReflectionException
      */
-    public function invoke($invokeInTestsOnly = false): void
+    public function invoke($invokeInTestsOnly = false, $consumersToProcess = []): void
     {
         if ($invokeInTestsOnly) {
             $trace = (new \Exception())->getTraceAsString();
-            if (false === strpos($trace, 'src/Framework/TestCase.php')
+            if (false === strpos($trace, 'Magento\GraphQl')
+                || false === strpos($trace, 'src/Framework/TestCase.php')
                 || false !== strpos($trace, 'ApiDataFixture->startTest')) {
                 return;
             }
@@ -48,7 +51,9 @@ class ConsumerInvoker
 
         /** @var \Magento\Framework\MessageQueue\ConsumerFactory $consumerFactory */
         $consumerFactory = $objectManager->create(\Magento\Framework\MessageQueue\ConsumerFactory::class);
-        foreach (self::CONSUMERS as $consumerName) {
+        $consumersToProcess = $consumersToProcess ?: self::CONSUMERS;
+
+        foreach ($consumersToProcess as $consumerName) {
             $consumer = $consumerFactory->get($consumerName, self::BATCHSIZE);
             $consumer->process(self::BATCHSIZE);
         }

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/UseCase/MixSyncAndAsyncSingleQueueTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/UseCase/MixSyncAndAsyncSingleQueueTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\MessageQueue\UseCase;
+
+use Magento\Framework\App\DeploymentConfig\FileReader;
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Filesystem;
+
+/**
+ * Override \Magento\Framework\MessageQueue\UseCase\MixSyncAndAsyncSingleQueueTest
+ * Should be eliminated after resolving MC-32269 for 2.4
+ */
+class MixSyncAndAsyncSingleQueueTest extends QueueTestCaseAbstract
+{
+    /**
+     * @var \Magento\TestModuleAsyncAmqp\Model\AsyncTestData
+     */
+    protected $msgObject;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $consumers = ['mixed.sync.and.async.queue.consumer'];
+
+    /**
+     * @var string[]
+     */
+    protected $messages = ['message1', 'message2', 'message3'];
+
+    /**
+     * @var int
+     */
+    protected $maxMessages = 4;
+
+    /**
+     * @var FileReader
+     */
+    private $reader;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->reader = $this->objectManager->get(FileReader::class);
+        $this->filesystem = $this->objectManager->get(Filesystem::class);
+        $this->config = $this->loadConfig();
+    }
+
+    public function testMixSyncAndAsyncSingleQueue()
+    {
+        $this->publisherConsumerController->stopConsumers();
+
+        $config = $this->config;
+        $config['queue']['consumers_wait_for_messages'] = 1;
+        $this->writeConfig($config);
+        $this->assertArraySubset(['queue' => ['consumers_wait_for_messages' => 1]], $this->loadConfig());
+
+        $this->msgObject = $this->objectManager->create(\Magento\TestModuleAsyncAmqp\Model\AsyncTestData::class);
+
+        $this->publisherConsumerController->startConsumers();
+
+        // Publish asynchronous messages
+        foreach ($this->messages as $item) {
+            $this->msgObject->setValue($item);
+            $this->msgObject->setTextFilePath($this->logFilePath);
+            $this->publisher->publish('multi.topic.queue.topic.c', $this->msgObject);
+        }
+
+        // Publish synchronous message to the same queue
+        $input = 'Input value';
+        $response = $this->publisher->publish('sync.topic.for.mixed.sync.and.async.queue', $input);
+        $this->assertEquals($input . ' processed by RPC handler', $response);
+
+        $this->waitForAsynchronousResult(count($this->messages), $this->logFilePath);
+
+        // Verify that asynchronous messages were processed
+        foreach ($this->messages as $item) {
+            $this->assertContains($item, file_get_contents($this->logFilePath));
+        }
+
+        $this->rollbackConsumerWaitConfig();
+    }
+
+    /**
+     * To prevent failure \Magento\TestFramework\Isolation\DeploymentConfig::endTest which executed before tearDown
+     */
+    private function rollbackConsumerWaitConfig()
+    {
+        $this->writeConfig($this->config);
+    }
+
+    /**
+     * @return array
+     */
+    private function loadConfig(): array
+    {
+        return $this->reader->load(ConfigFilePool::APP_ENV);
+    }
+
+    /**
+     * @param array $config
+     */
+    private function writeConfig(array $config): void
+    {
+        $writer = $this->objectManager->get(Writer::class);
+        $writer->saveConfig([ConfigFilePool::APP_ENV => $config], true);
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/UseCase/WaitAndNotWaitMessagesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/UseCase/WaitAndNotWaitMessagesTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\MessageQueue\UseCase;
+
+use Magento\Framework\App\DeploymentConfig\FileReader;
+use Magento\TestModuleAsyncAmqp\Model\AsyncTestData;
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Filesystem;
+
+/**
+ * Override \Magento\Framework\MessageQueue\UseCase\WaitAndNotWaitMessagesTest
+ * Should be eliminated after resolving MC-32269 for 2.4
+ */
+class WaitAndNotWaitMessagesTest extends QueueTestCaseAbstract
+{
+    /**
+     * @var FileReader
+     */
+    private $reader;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @var AsyncTestData
+     */
+    protected $msgObject;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $consumers = ['mixed.sync.and.async.queue.consumer'];
+
+    /**
+     * @var string[]
+     */
+    protected $messages = ['message1', 'message2', 'message3'];
+
+    /**
+     * @var int|null
+     */
+    protected $maxMessages = 4;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->msgObject = $this->objectManager->create(AsyncTestData::class);
+        $this->reader = $this->objectManager->get(FileReader::class);
+        $this->filesystem = $this->objectManager->get(Filesystem::class);
+        $this->config = $this->loadConfig();
+    }
+
+    /**
+     * Check if consumers wait for messages from the queue
+     */
+    public function testWaitForMessages()
+    {
+        $this->publisherConsumerController->stopConsumers();
+
+        $config = $this->config;
+        $config['queue']['consumers_wait_for_messages'] = 1;
+        $this->writeConfig($config);
+
+        $this->assertArraySubset(['queue' => ['consumers_wait_for_messages' => 1]], $this->loadConfig());
+
+        foreach ($this->messages as $message) {
+            $this->publishMessage($message);
+        }
+
+        $this->publisherConsumerController->startConsumers();
+        $this->waitForAsynchronousResult(count($this->messages), $this->logFilePath);
+
+        foreach ($this->messages as $item) {
+            $this->assertContains($item, file_get_contents($this->logFilePath));
+        }
+
+        $this->publishMessage('message4');
+        $this->waitForAsynchronousResult(count($this->messages) + 1, $this->logFilePath);
+        $this->assertContains('message4', file_get_contents($this->logFilePath));
+
+        $this->rollbackConsumerWaitConfig();
+    }
+
+    /**
+     * Check if consumers do not wait for messages from the queue and die
+     */
+    public function testNotWaitForMessages(): void
+    {
+        $this->publisherConsumerController->stopConsumers();
+
+        $config = $this->config;
+        $config['queue']['consumers_wait_for_messages'] = 0;
+        $this->writeConfig($config);
+
+        $this->assertArraySubset(['queue' => ['consumers_wait_for_messages' => 0]], $this->loadConfig());
+        foreach ($this->messages as $message) {
+            $this->publishMessage($message);
+        }
+
+        $this->publisherConsumerController->startConsumers();
+        $this->waitForAsynchronousResult(count($this->messages), $this->logFilePath);
+
+        foreach ($this->messages as $item) {
+            $this->assertContains($item, file_get_contents($this->logFilePath));
+        }
+
+        // Checks that consumers do not wait 4th message and die
+        $this->assertArraySubset(
+            ['mixed.sync.and.async.queue.consumer' => []],
+            $this->publisherConsumerController->getConsumersProcessIds()
+        );
+        $this->rollbackConsumerWaitConfig();
+    }
+
+    /**
+     * @param string $message
+     */
+    private function publishMessage(string $message): void
+    {
+        $this->msgObject->setValue($message);
+        $this->msgObject->setTextFilePath($this->logFilePath);
+        $this->publisher->publish('multi.topic.queue.topic.c', $this->msgObject);
+    }
+
+    /**
+     * @return array
+     */
+    private function loadConfig(): array
+    {
+        return $this->reader->load(ConfigFilePool::APP_ENV);
+    }
+
+    /**
+     * @param array $config
+     */
+    private function writeConfig(array $config): void
+    {
+        $writer = $this->objectManager->get(Writer::class);
+        $writer->saveConfig([ConfigFilePool::APP_ENV => $config], true);
+    }
+
+    /**
+     * To prevent failure \Magento\TestFramework\Isolation\DeploymentConfig::endTest which executed before tearDown
+     */
+    private function rollbackConsumerWaitConfig()
+    {
+        $this->writeConfig($this->config);
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/GraphQl/AbstractGraphQl.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/AbstractGraphQl.php
@@ -20,39 +20,25 @@ use PHPUnit\Framework\TestCase;
 abstract class AbstractGraphQl extends TestCase
 {
     /**
-     * @var int
-     */
-    private $maxMessages = 500;
-
-    /**
      * Process storefront consumers during test setup
      *
      * @throws LocalizedException
      */
     protected function setUp(): void
     {
-        $consumers = [
-            'storefront.catalog.category.update',
-            'storefront.catalog.product.update',
-            'storefront.catalog.data.consume',
-        ];
-        $this->processCatalogQueueMessages($consumers);
+        $this->processCatalogQueueMessages();
     }
 
     /**
      * Process provided consumers list
      *
-     * @param array $consumers
      * @throws LocalizedException
      */
-    protected function processCatalogQueueMessages(array $consumers): void
+    protected function processCatalogQueueMessages(): void
     {
         $objectManager = Bootstrap::getObjectManager();
-        /** @var ConsumerFactory $consumerFactory */
-        $consumerFactory = $objectManager->create(ConsumerFactory::class);
-        foreach ($consumers as $consumerName) {
-            $consumer = $consumerFactory->get($consumerName, 1000);
-            $consumer->process($this->maxMessages);
-        }
+        /** @var \Magento\TestFramework\Workaround\ConsumerInvoker $consumerInvoker */
+        $consumerInvoker = $objectManager->get(\Magento\TestFramework\Workaround\ConsumerInvoker::class);
+        $consumerInvoker->invoke();
     }
 }


### PR DESCRIPTION
MC-31906: [BUG] Critical error while saving category
https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/30510/

NOTE:
Any background process should be restarted if the application state was changed (due to a lot of internal services are not stateless)
To restart the application Poison Pill (\Magento\MessageQueue\Model\ResourceModel\PoisonPill) was introduced. Currently, the Poison Pill used only in \Magento\Framework\MessageQueue\Consumer and not supported in  \Magento\Framework\MessageQueue\BatchConsumer

But after switching from BatchConsumer to Consumer we faced with issue in web-api/integration tests: by default Consumer running until processing X messages (BatchConsumer just process all messages and die)
To handle this issue we change deployment configuration (env.php) "queue.consumers_wait_for_messages"  from "1" to "0". To enable this you must run tests with custom infra branch: https://github.com/magento-performance/magento2-infrastructure/tree/2.3.4-develop-storefront


