### PR TITLE
ECP-531: Fix current data sync bugs

### DIFF
--- a/app/code/Magento/CatalogStorefrontConnector/Model/Publisher/ProductPublisher.php
+++ b/app/code/Magento/CatalogStorefrontConnector/Model/Publisher/ProductPublisher.php
@@ -123,7 +123,7 @@ class ProductPublisher
                 \sprintf('Publish products with ids "%s" in store %s', \implode(', ', $productIds), $storeId),
                 ['verbose' => $productsData]
             );
-            foreach ($productIds as $productId) {
+            foreach ($idsBunch as $productId) {
                 $product = $productsData[$productId] ?? [];
                 $messages[] = $this->messageBuilder->build(
                     $storeId,


### PR DESCRIPTION
- Fixed wrong batching

The issue was triggered by combinations of two things:
- Broken batching that was producing empty payload for some messages
- The empty payload is considered as `product_remove` operation on storefront side