### PR TITLE
Ticket #62: Magento.CatalogStaging added a fix in the category tree

### DIFF
--- a/app/code/Magento/CatalogStorefrontGraphQl/Resolver/Category/CategoryTree.php
+++ b/app/code/Magento/CatalogStorefrontGraphQl/Resolver/Category/CategoryTree.php
@@ -148,10 +148,10 @@ class CategoryTree implements BatchResolverInterface
         ContextInterface $context,
         Field $field
     ): array {
-        if ($field->getName() === 'category') {
-            $scopes = $this->scopeProvider->getScopes($context);
+        $scopes = $this->scopeProvider->getScopes($context);
+        $storefrontRequest = ['scopes' => $scopes, 'store' => $scopes['store']];
 
-            $storefrontRequest = ['scopes' => $scopes, 'store' => $scopes['store']];
+        if ($field->getName() === 'category') {
             $categoryId = $request->getArgs()['id'] ?? null;
             if ($categoryId === null) {
                 $store = $context->getExtensionAttributes()->getStore();


### PR DESCRIPTION
### Description (*)
resolve magento/catalog-storefront#62

Fixed missing scope in child category data, leading to error when trying to retrieve child category data in graphQl

### Related Pull Requests
https://github.com/magento/catalog-storefront-ee/pull/3

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)