### PR TITLE
Configurable product variants api-test added

### DIFF
--- a/app/code/Magento/CatalogStorefront/Test/Api/Product/ProductVariants/ConfigurableProductVariantsTest.php
+++ b/app/code/Magento/CatalogStorefront/Test/Api/Product/ProductVariants/ConfigurableProductVariantsTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogStorefront\Test\Api\Product\ProductVariants;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\CatalogStorefront\Model\CatalogService;
+use Magento\CatalogStorefront\Test\Api\StorefrontTestsAbstract;
+use Magento\CatalogStorefrontApi\Api\Data\ProductVariantsGetRequestInterface;
+use Magento\CatalogStorefrontApi\Api\Data\ProductVariantArrayMapper;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Helper\CompareArraysRecursively;
+
+/**
+ * Tests configurable product variants on the storefront
+ */
+class ConfigurableProductVariantsTest extends StorefrontTestsAbstract
+{
+    const STORE_CODE = 'default';
+
+    /**
+     * @var string[]
+     */
+    private $attributesToCompare = [
+        'variants'
+    ];
+
+    /**
+     * @var CatalogService
+     */
+    private $catalogService;
+
+    /**
+     * @var ProductVariantsGetRequestInterface
+     */
+    private $productVariantsGetRequestInterface;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    /**
+     * @var ProductVariantArrayMapper
+     */
+    private $arrayMapper;
+
+    /**
+     * @var CompareArraysRecursively
+     */
+    private $compareArraysRecursively;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->catalogService = Bootstrap::getObjectManager()->create(CatalogService::class);
+        $this->productVariantsGetRequestInterface = Bootstrap::getObjectManager()->create(ProductVariantsGetRequestInterface::class);
+        $this->productRepository = Bootstrap::getObjectManager()->create(ProductRepositoryInterface::class);
+        $this->arrayMapper = Bootstrap::getObjectManager()->create(ProductVariantArrayMapper::class);
+        $this->compareArraysRecursively = Bootstrap::getObjectManager()->create(CompareArraysRecursively::class);
+    }
+
+    /**
+     * Test configurable product variants
+     *
+     * @magentoApiDataFixture Magento/ConfigurableProduct/_files/configurable_product_with_two_child_products.php
+     * @magentoDbIsolation disabled
+     * @param array $expected
+     * @throws NoSuchEntityException
+     * @dataProvider configurableProductVariantsProvider
+     */
+    public function testConfigurableProductVariantsData(array $expected): void
+    {
+        $configurableProduct = $this->productRepository->get('Configurable product');
+
+        $this->productVariantsGetRequestInterface->setIds([$configurableProduct->getId()]);
+        $this->productVariantsGetRequestInterface->setStoreId(self::STORE_CODE);
+        $this->productVariantsGetRequestInterface->setAttributeCodes($this->attributesToCompare);
+        $catalogServiceItem = $this->catalogService->getProductVariants($this->productVariantsGetRequestInterface);
+        self::assertNotEmpty($catalogServiceItem->getItems());
+
+        $actual = [];
+        foreach ($catalogServiceItem->getItems()[0]->getAttributes() as $item) {
+            $actual[] = $this->arrayMapper->convertToArray($item);
+        }
+
+        $diff = $this->compareArraysRecursively->execute(
+            $expected,
+            $actual
+        );
+        self::assertEquals([], $diff, "Actual response doesn't equal expected data");
+    }
+
+    /**
+     * Data provider for configurable product variants
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @return array
+     */
+    public function configurableProductVariantsProvider(): array
+    {
+        return [
+            [
+                [
+                    [
+                        'label' => 'Option 1',
+                        'code' => 'test_configurable',
+                        'value_index' => '13',
+                        'attribute_id' => '179'
+                    ],
+                    [
+                        'label' => 'Option 2',
+                        'code' => 'test_configurable',
+                        'value_index' => '14',
+                        'attribute_id' => '179'
+                    ]
+                ]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/catalog-storefront#<issue_number>


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Code Review Checklist (*)

See dataied [checklist](https://github.com/magento/catalog-storefront/wiki/Code-Review-checklist)

- [ ] Story AC is completed
- [ ] proposed changes correspond to [Magento Technical Vision](https://devdocs.magento.com/guides/v2.2/coding-standards/technical-guidelines.html)
- [ ] new or changed code is covered with web-api/integration tests (if applicable)
  - expected results in test verified with data from fixture
- [ ] no backward incompatibile changes
- [ ] Export API (et_schema.xml) and SF API schemas (proto schema) are reflected in the codebase
  - prerequisite: story branch created with all needed generated classes according to proposes schema-changes
  - DTO classes do not contain any manual changes (Magento\CatalogExportApi\*, Magento\CatalogStorefrontApi\*)
- [ ] Class usage: magento/catalog-storefront repo don't use directly classes from magento/saas-export repo and vise-verse
  - Check composer.json dependencies
- [ ] Legacy code is deleted
  - Any Data Providers present in Connector part  (Magento\CatalogStorefrontConnector, Magento\*Extractor modules)
  - And Data Providers from Export API (magento/saas-export repo) that is not relevant anymore
  - Any DTO for Export API/SF API which does not reflect current schema: et_schema, proto schema
  - Any “mapper” on Message Broker (between Export API and SF API)
    - if mapper still needed, verify fields used in mapping, remove not relevant fields


