### PR TITLE
Updated schema for the downloadable links

### DIFF
--- a/magento.proto
+++ b/magento.proto
@@ -88,12 +88,6 @@ message Product {
     string price_view = 96;
     repeated BundleItem items = 97;
 
-    //DOWNLOADABLE
-    bool links_purchased_separately = 98;
-    string links_title = 99;
-    repeated DownloadableLink downloadable_product_links = 100;
-    repeated DownloadableSample downloadable_product_samples = 101;
-
     float only_x_left_in_stock = 102;
 
     repeated GroupedItem grouped_items = 103;
@@ -154,29 +148,6 @@ message ProductShopperInputOption {
   repeated string file_extension = 9;
   int32 image_size_x = 10;
   int32 image_size_y = 11;
-}
-
-message DownloadableLink {
-    string sample_url = 1;
-    string title = 2;
-    int32 sort_order = 3;
-    string sample_type = 4;
-    string sample_file = 5;
-    int32 link_id = 6;
-    float price = 7;
-    string link_type = 8;
-    bool is_shareable = 9;
-    int32 number_of_downloads = 10;
-    string entity_id = 11;
-}
-
-message DownloadableSample {
-    string sample_url = 1;
-    string title = 2;
-    int32 sort_order = 3;
-    string sample_type = 4;
-    string sample_file = 5;
-    string entity_id = 6;
 }
 
 message BundleItem {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Update the Proto scheme with the new fields for Downloadable links

### Related Pull Requests
https://github.com/magento/saas-export/pull/128
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/catalog-storefront#191


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Code Review Checklist (*)

See dataied [checklist](https://github.com/magento/catalog-storefront/wiki/Code-Review-checklist)

- [ ] Story AC is completed
- [ ] proposed changes correspond to [Magento Technical Vision](https://devdocs.magento.com/guides/v2.2/coding-standards/technical-guidelines.html)
- [ ] new or changed code is covered with web-api/integration tests (if applicable)
  - expected results in test verified with data from fixture
- [ ] no backward incompatibile changes
- [ ] Export API (et_schema.xml) and SF API schemas (proto schema) are reflected in the codebase
  - prerequisite: story branch created with all needed generated classes according to proposes schema-changes
  - DTO classes do not contain any manual changes (Magento\CatalogExportApi\*, Magento\CatalogStorefrontApi\*)
- [ ] Class usage: magento/catalog-storefront repo don't use directly classes from magento/saas-export repo and vise-verse
  - Check composer.json dependencies
- [ ] Legacy code is deleted
  - Any Data Providers present in Connector part  (Magento\CatalogStorefrontConnector, Magento\*Extractor modules)
  - And Data Providers from Export API (magento/saas-export repo) that is not relevant anymore
  - Any DTO for Export API/SF API which does not reflect current schema: et_schema, proto schema
  - Any “mapper” on Message Broker (between Export API and SF API)
    - if mapper still needed, verify fields used in mapping, remove not relevant fields


