### PR TITLE
Product images not found for SF API

### DIFF
--- a/app/code/Magento/CatalogStorefront/Test/Api/Product/Downloadable/SamplesTest.php
+++ b/app/code/Magento/CatalogStorefront/Test/Api/Product/Downloadable/SamplesTest.php
@@ -13,6 +13,8 @@ use Magento\CatalogStorefront\Test\Api\StorefrontTestsAbstract;
 use Magento\CatalogStorefrontApi\Api\Data\ProductsGetRequestInterface;
 use Magento\CatalogStorefrontApi\Api\Data\SampleArrayMapper;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
 /**
@@ -48,6 +50,11 @@ class SamplesTest extends StorefrontTestsAbstract
     private $arrayMapper;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * @inheritdoc
      */
     protected function setUp(): void
@@ -57,6 +64,7 @@ class SamplesTest extends StorefrontTestsAbstract
         $this->productsGetRequestInterface = Bootstrap::getObjectManager()->create(ProductsGetRequestInterface::class);
         $this->productRepository = Bootstrap::getObjectManager()->create(ProductRepositoryInterface::class);
         $this->arrayMapper = Bootstrap::getObjectManager()->create(SampleArrayMapper::class);
+        $this->storeManager = Bootstrap::getObjectManager()->create(StoreManagerInterface::class);
     }
 
     /**
@@ -119,9 +127,11 @@ class SamplesTest extends StorefrontTestsAbstract
 
         $this->compare($dataProvider, $actual);
 
+        $baseUrl = $this->storeManager->getStore(self::STORE_CODE)->getBaseUrl(UrlInterface::URL_TYPE_WEB);
         $sample = $product->getExtensionAttributes()->getDownloadableProductSamples()[0];
-        self::assertStringEndsWith(
-            \sprintf('/downloadable/download/sample/sample_id/%s', $sample->getId()),
+
+        self::assertEquals(
+            \sprintf('%sdownloadable/download/sample/sample_id/%s', $baseUrl, $sample->getId()),
             $actual['resource']['url']
         );
     }

--- a/app/code/Magento/CatalogStorefront/Test/Api/Product/ProductOptions/DownloadLinksTest.php
+++ b/app/code/Magento/CatalogStorefront/Test/Api/Product/ProductOptions/DownloadLinksTest.php
@@ -13,6 +13,8 @@ use Magento\CatalogStorefront\Test\Api\StorefrontTestsAbstract;
 use Magento\CatalogStorefrontApi\Api\Data\ProductsGetRequestInterface;
 use Magento\CatalogStorefrontApi\Api\Data\ProductOptionArrayMapper;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
 /**
@@ -55,6 +57,11 @@ class DownloadLinksTest extends StorefrontTestsAbstract
     protected $arrayMapper;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * @inheritdoc
      */
     protected function setUp(): void
@@ -64,6 +71,7 @@ class DownloadLinksTest extends StorefrontTestsAbstract
         $this->productsGetRequestInterface = Bootstrap::getObjectManager()->create(ProductsGetRequestInterface::class);
         $this->productRepository = Bootstrap::getObjectManager()->create(ProductRepositoryInterface::class);
         $this->arrayMapper = Bootstrap::getObjectManager()->create(ProductOptionArrayMapper::class);
+        $this->storeManager = Bootstrap::getObjectManager()->create(StoreManagerInterface::class);
     }
 
     /**
@@ -137,9 +145,11 @@ class DownloadLinksTest extends StorefrontTestsAbstract
 
         $this->compare($expected, $actual);
 
+        $baseUrl = $this->storeManager->getStore(self::STORE_CODE)->getBaseUrl(UrlInterface::URL_TYPE_WEB);
         $link = $product->getExtensionAttributes()->getDownloadableProductLinks()[0];
-        self::assertStringEndsWith(
-            \sprintf('/downloadable/download/linkSample/link_id/%s', $link->getId()),
+
+        self::assertEquals(
+            \sprintf('%sdownloadable/download/linkSample/link_id/%s', $baseUrl, $link->getId()),
             $actual[0]['values'][0]['info_url']
         );
     }


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
https://github.com/magento/saas-export/pull/142
https://github.com/magento/partners-magento2-infrastructure/pull/42
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/catalog-storefront#367


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Code Review Checklist (*)

See dataied [checklist](https://github.com/magento/catalog-storefront/wiki/Code-Review-checklist)

- [ ] Story AC is completed
- [ ] proposed changes correspond to [Magento Technical Vision](https://devdocs.magento.com/guides/v2.2/coding-standards/technical-guidelines.html)
- [ ] new or changed code is covered with web-api/integration tests (if applicable)
  - expected results in test verified with data from fixture
- [ ] no backward incompatibile changes
- [ ] Export API (et_schema.xml) and SF API schemas (proto schema) are reflected in the codebase
  - prerequisite: story branch created with all needed generated classes according to proposes schema-changes
  - DTO classes do not contain any manual changes (Magento\CatalogExportApi\*, Magento\CatalogStorefrontApi\*)
- [ ] Class usage: magento/catalog-storefront repo don't use directly classes from magento/saas-export repo and vise-verse
  - Check composer.json dependencies
- [ ] Legacy code is deleted
  - Any Data Providers present in Connector part  (Magento\CatalogStorefrontConnector, Magento\*Extractor modules)
  - And Data Providers from Export API (magento/saas-export repo) that is not relevant anymore
  - Any DTO for Export API/SF API which does not reflect current schema: et_schema, proto schema
  - Any “mapper” on Message Broker (between Export API and SF API)
    - if mapper still needed, verify fields used in mapping, remove not relevant fields